### PR TITLE
Fix conda environment filename

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: /Users/gm105550/anaconda3
+name: portfolio_env
 channels:
   - defaults
 dependencies:


### PR DESCRIPTION
## Summary
- rename `environnement.yml` to `environment.yml`
- set a portable environment name inside the file

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68425bd70e44832fbe194ba4e7fc3dd0