### PR TITLE
Fix README env filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Steps
 
 1. Clone this repo
-2. Run `conda env create -f environment.yml` to create conda environment
+2. Run `conda env create -f environnement.yml` to create conda environment
 3. Run `conda activate portfolio_env` to activate conda environment
 4. Required packages are installed in `requirements.txt`
 5. Run `mkdocs serve` to test locally


### PR DESCRIPTION
## Summary
- fix the conda environment creation command in README so it points to `environnement.yml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843ddc65de0832f8dabe60ddd1c6705