### PR TITLE
Add docs build workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,20 @@
+name: Build Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Build documentation
+        run: mkdocs build --strict
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build documentation

## Testing
- `pip install -r requirements.txt` *(fails: Expected package name)*
- `mkdocs build --strict` *(fails: unrecognised theme name)*

------
https://chatgpt.com/codex/tasks/task_e_6843ddce6af4832fa78248fae646b1dd